### PR TITLE
Rename member to use snake_case naming convention

### DIFF
--- a/rpn-calc/src/calculator.py
+++ b/rpn-calc/src/calculator.py
@@ -7,37 +7,37 @@ class Calculator:
     '''
 
     def __init__(self):
-        self.theStack = Stack()
+        self.the_stack = Stack()
 
     def parse(self, token: str):
         '''
         Process the token.
-        Operands pop the required number of tokens from the self.theStack and
+        Operands pop the required number of tokens from the self.the_stack and
         push the operand result.
-        "p" or "" (empty string) pop and print the top-most self.theStack
+        "p" or "" (empty string) pop and print the top-most self.the_stack
         element.
         Anything else is assumed to be a float, and is pushed.
         '''
         match token:
             case "+":
-                self.theStack.push(
-                    self.theStack.pop() + self.theStack.pop()
+                self.the_stack.push(
+                    self.the_stack.pop() + self.the_stack.pop()
                 )
             case "-":
-                self.theStack.push(
-                    self.theStack.pop() - self.theStack.pop()
+                self.the_stack.push(
+                    self.the_stack.pop() - self.the_stack.pop()
                 )
             case "*":
-                self.theStack.push(
-                    self.theStack.pop() * self.theStack.pop()
+                self.the_stack.push(
+                    self.the_stack.pop() * self.the_stack.pop()
                 )
             case "/":
-                self.theStack.push(
-                    self.theStack.pop() / self.theStack.pop()
+                self.the_stack.push(
+                    self.the_stack.pop() / self.the_stack.pop()
                 )
             case "p":
-                token = self.theStack.pop()
+                token = self.the_stack.pop()
                 print(token)
                 return token
             case _:
-                self.theStack.push(float(token))
+                self.the_stack.push(float(token))


### PR DESCRIPTION
`snake_case` is the usual Python convention (rather than `camelCase`). The rest of the project uses snake case (e.g. `the_stack` in `stack.py`.